### PR TITLE
fix: remove Docker Hub from CI workflow

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -74,13 +74,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        if: ${{ github.ref_name == 'main' }}
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
@@ -129,13 +122,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        if: ${{ github.ref_name == 'main' }}
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push by digest
         id: build
@@ -216,12 +202,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Create manifest list and push to GHCR
         working-directory: /tmp/digests
         run: |
@@ -230,39 +210,6 @@ jobs:
             -t ghcr.io/${{ env.REPO_LC }}:${{ needs.release.outputs.new_release_version }} \
             $(printf 'ghcr.io/${{ env.REPO_LC }}@sha256:%s ' *)
 
-      - name: Push to Docker Hub
-        working-directory: /tmp/digests
-        run: |
-          # Tag and push each digest to Docker Hub
-          for digest in *; do
-            docker buildx imagetools create \
-              -t ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:digest-${digest} \
-              ghcr.io/${{ env.REPO_LC }}@sha256:${digest}
-          done
-
-          # Create multi-arch manifest for Docker Hub
-          docker buildx imagetools create \
-            -t ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:latest \
-            -t ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:${{ needs.release.outputs.new_release_version }} \
-            $(printf 'ghcr.io/${{ env.REPO_LC }}@sha256:%s ' *)
-
-      - name: Inspect images
+      - name: Inspect image
         run: |
           docker buildx imagetools inspect ghcr.io/${{ env.REPO_LC }}:latest
-          docker buildx imagetools inspect ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:latest
-
-  update-dockerhub-description:
-    name: Update Docker Hub Description
-    needs: [push-manifest]
-    if: ${{ github.ref_name == 'main' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Update Docker Hub repo description
-        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd


### PR DESCRIPTION
## Summary
- Remove Docker Hub login steps from build jobs
- Remove Docker Hub push steps from push-manifest job
- Remove update-dockerhub-description job
- Only push container images to GHCR

## Reason
Docker Hub credentials are not configured in this fork. Simplify CI to only use GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)