### PR TITLE
fix(ci): reorder pipeline so semantic-release runs before builds

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -50,9 +50,36 @@ jobs:
       - name: Run tests
         run: npm run test
 
+  release:
+    name: Semantic Release
+    needs: [test-go, test-node]
+    if: ${{ github.ref_name == 'main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    outputs:
+      new_release_published: ${{ steps.release.outputs.new_release_published }}
+      new_release_version: ${{ steps.release.outputs.new_release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v4
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-amd64:
     name: Build amd64
-    needs: [test-go, test-node]
+    needs: [test-go, test-node, release]
+    if: ${{ always() && needs.test-go.result == 'success' && needs.test-node.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -61,10 +88,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Fetch tags
+        run: git fetch --tags --force
 
       - name: Determine version
         id: version
-        run: echo "version=$(git describe --tags --always 2>/dev/null || echo dev)" >> $GITHUB_OUTPUT
+        run: |
+          RELEASE_VERSION="${{ needs.release.outputs.new_release_version }}"
+          if [ -n "$RELEASE_VERSION" ]; then
+            echo "version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+          else
+            echo "version=$(git describe --tags --always 2>/dev/null || echo dev)" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set lowercase repo name
         run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
@@ -109,7 +146,8 @@ jobs:
 
   build-arm64:
     name: Build arm64
-    needs: [test-go, test-node]
+    needs: [test-go, test-node, release]
+    if: ${{ always() && needs.test-go.result == 'success' && needs.test-node.result == 'success' }}
     runs-on: ubuntu-24.04-arm
     permissions:
       packages: write
@@ -118,10 +156,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Fetch tags
+        run: git fetch --tags --force
 
       - name: Determine version
         id: version
-        run: echo "version=$(git describe --tags --always 2>/dev/null || echo dev)" >> $GITHUB_OUTPUT
+        run: |
+          RELEASE_VERSION="${{ needs.release.outputs.new_release_version }}"
+          if [ -n "$RELEASE_VERSION" ]; then
+            echo "version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+          else
+            echo "version=$(git describe --tags --always 2>/dev/null || echo dev)" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set lowercase repo name
         run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
@@ -164,35 +212,9 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  release:
-    name: Semantic Release
-    needs: [build-amd64, build-arm64]
-    if: ${{ github.ref_name == 'main' }}
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: write
-      issues: write
-      pull-requests: write
-      id-token: write
-    outputs:
-      new_release_published: ${{ steps.release.outputs.new_release_published }}
-      new_release_version: ${{ steps.release.outputs.new_release_version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4
-        id: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   push-manifest:
     name: Push Multi-arch Manifest
-    needs: [release]
+    needs: [release, build-amd64, build-arm64]
     if: ${{ github.ref_name == 'main' && needs.release.outputs.new_release_published == 'true' }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Fixes the version mismatch where the Docker image reports `v1.16.0-1-gd9851d8` instead of `1.17.0`. The CI pipeline was building the binary *before* semantic-release created the git tag, so `git describe` fell back to the previous tag + offset.

## Changes

Restructured the job dependency graph in `docker-ci.yaml`:

**Before:** tests → builds (`git describe` = wrong) → semantic-release (creates tag) → manifest
**After:** tests → semantic-release (creates tag) → builds (uses release version) → manifest

- Build jobs now use `needs.release.outputs.new_release_version` when available
- Falls back to `git describe` for non-release builds (feature branches)
- Added `git fetch --tags --force` step so builds see newly created tags
- Build jobs use `if: always() && tests passed` to run even when release is skipped (non-main branches)

## Test plan

- [ ] Merge this PR — semantic-release will create a new version
- [ ] Verify the new container image reports the correct version via `GET /health`
- [ ] Verify feature branch CI still runs builds without the release job

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)