### PR TITLE
fix(swarmcd): only update LastDeployedAt on revision change

### DIFF
--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -54,14 +54,14 @@ func updateStackThread(swarmStack *swarmStack, waitGroup *sync.WaitGroup) {
 
 	status := stackStatus[swarmStack.name]
 
-	// Set LastChangeAt when the revision changes
+	// Update timestamps only when the revision actually changes
 	if revision != status.Revision {
 		status.LastChangeAt = &now
+		status.LastDeployedAt = &now
 	}
 
 	status.Error = ""
 	status.Revision = revision
-	status.LastDeployedAt = &now
 	stateMu.Unlock()
 	logger.Info(fmt.Sprintf("done updating %s stack", swarmStack.name))
 }


### PR DESCRIPTION
## Summary

`LastDeployedAt` was set on every reconciliation cycle (~30s), making it reflect "last reconciler run" rather than "last actual deployment." Moved it inside the revision-change guard so it only updates when a new revision is detected — matching the `LastChangeAt` semantics.

The same fix has been pushed to upstream PRs #158 (delta) and #159 (epsilon).

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)