### PR TITLE
feat(release): mirror multi-arch manifest to Docker Hub oakandwave + sign both registries

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -228,8 +228,18 @@ jobs:
     if: ${{ github.ref_name == 'main' && needs.release.outputs.new_release_published == 'true' }}
     runs-on: ubuntu-latest
     permissions:
+      # `contents: read` must be explicit: naming ANY permission sets every unnamed one to
+      # `none`, and this job now checks out the repo (for scripts/ci/ below). Matches the
+      # three sibling repos already on this action.
+      contents: read
       packages: write
+      id-token: write # keyless cosign (Fulcio/Rekor) via the shared oaw-sign-image action
     steps:
+      - name: Checkout
+        # This job previously needed no checkout (it only assembles manifests from the build
+        # jobs' digest artifacts), but scripts/ci/resolve-index-digest.sh below is a repo file.
+        uses: actions/checkout@v4
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -262,6 +272,37 @@ jobs:
         run: |
           docker buildx imagetools inspect ghcr.io/${{ env.REPO_LC }}:latest
 
+      - name: Resolve the manifest-list digest
+        # `imagetools create` does not expose the digest of the index it just created, so
+        # resolve it explicitly -- the sign steps below must target an immutable digest, not
+        # a tag (the shared action hard-refuses any ref lacking @sha256:, so a mistake here
+        # fails loudly rather than signing whatever the tag later points at).
+        #
+        # This is the INDEX digest, and it is deliberately the thing we sign: a consumer
+        # pulls the tag, which resolves to the index, so one signature on the index covers
+        # both arches. Signing the per-arch child digests in the build jobs instead would
+        # leave `cosign verify <tag>` finding nothing.
+        #
+        # The script (not an inline run block) carries the buildx --format caveat and the
+        # sha256 guard, and is locally testable against a real registry.
+        #
+        # Invoked via `bash`, not a direct exec, so this never depends on the execute bit
+        # surviving checkout -- a mode loss would fail exit 126 only on a real release (this
+        # job never runs on a PR), and the shared action encodes the same lesson.
+        id: digest
+        run: bash ./scripts/ci/resolve-index-digest.sh "ghcr.io/${REPO_LC}:${VERSION}"
+        env:
+          VERSION: ${{ needs.release.outputs.new_release_version }}
+
+      - name: Sign the GHCR manifest list (cosign keyless + SBOM)
+        # Consumer of cc-workflow's reusable oaw-sign-image action (fleet signing). The GHCR
+        # login above is active and this job's id-token grants OIDC. SBOM goes to rekor (the
+        # action default): syft over this index measures ~662 KB / 234 packages, well under
+        # rekor's request-body ceiling, so the TSA path (cc-workflow #995) is not needed.
+        uses: wave-engineering/claudecode-workflow/.github/actions/oaw-sign-image@21f10ce601b9340b30fd6df0b4a2e4bd663fe249
+        with:
+          digest-ref: ghcr.io/${{ env.REPO_LC }}@${{ steps.digest.outputs.digest }}
+
       - name: Log in to Docker Hub
         # OAT-safe here: push-manifest only runs imagetools against already-pushed GHCR
         # digests — no docker.io base pull happens in this job, so the oakandwave-scoped
@@ -280,6 +321,15 @@ jobs:
             -t docker.io/oakandwave/swarm-cd:latest \
             -t docker.io/oakandwave/swarm-cd:${{ needs.release.outputs.new_release_version }} \
             ghcr.io/${{ env.REPO_LC }}:${{ needs.release.outputs.new_release_version }}
+
+      - name: Sign the Docker Hub manifest list (cosign keyless + SBOM)
+        # `imagetools create` copies the index content-identically, so the Docker Hub index
+        # digest equals the GHCR one (verified: sha256:a2addc5d... on both registries) -- but
+        # cosign signatures are registry+digest-bound, so the mirror needs its own signature.
+        # The Docker Hub login above is active.
+        uses: wave-engineering/claudecode-workflow/.github/actions/oaw-sign-image@21f10ce601b9340b30fd6df0b4a2e4bd663fe249
+        with:
+          digest-ref: docker.io/oakandwave/swarm-cd@${{ steps.digest.outputs.digest }}
 
       - name: Docker Scout — CVE scan the pushed image
         # Non-blocking; continue-on-error covers ALL failures (auth/infra) so a Scout error

--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -124,6 +124,11 @@ jobs:
           context: .
           platforms: linux/amd64
           build-args: VERSION=${{ steps.version.outputs.version }}
+          # Lowercase OCI provenance labels, baked into the amd64 image config (swarm-cd
+          # has no metadata-action; hardcode them lowercase for the Docker Hub mirror).
+          labels: |
+            org.opencontainers.image.source=https://github.com/wave-engineering/swarm-cd
+            org.opencontainers.image.url=https://github.com/wave-engineering/swarm-cd
           cache-from: type=gha,scope=amd64
           cache-to: type=gha,mode=max,scope=amd64
           outputs: type=image,name=ghcr.io/${{ env.REPO_LC }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
@@ -192,6 +197,11 @@ jobs:
           context: .
           platforms: linux/arm64
           build-args: VERSION=${{ steps.version.outputs.version }}
+          # Lowercase OCI provenance labels, baked into the arm64 image config (matches
+          # the amd64 build so both arches carry the same source/url for the Docker Hub mirror).
+          labels: |
+            org.opencontainers.image.source=https://github.com/wave-engineering/swarm-cd
+            org.opencontainers.image.url=https://github.com/wave-engineering/swarm-cd
           cache-from: type=gha,scope=arm64
           cache-to: type=gha,mode=max,scope=arm64
           outputs: type=image,name=ghcr.io/${{ env.REPO_LC }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
@@ -251,3 +261,33 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ghcr.io/${{ env.REPO_LC }}:latest
+
+      - name: Log in to Docker Hub
+        # OAT-safe here: push-manifest only runs imagetools against already-pushed GHCR
+        # digests — no docker.io base pull happens in this job, so the oakandwave-scoped
+        # token is never asked to pull node/golang/alpine (that all happened in the build
+        # jobs, which do NOT log into Docker Hub). See flightdeck #20.
+        uses: docker/login-action@v3
+        with:
+          username: oakandwave
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Mirror multi-arch manifest to Docker Hub oakandwave
+        # Copy the assembled GHCR manifest list cross-registry (blobs + manifest) to
+        # docker.io/oakandwave. No rebuild; per-registry creds.
+        run: |
+          docker buildx imagetools create \
+            -t docker.io/oakandwave/swarm-cd:latest \
+            -t docker.io/oakandwave/swarm-cd:${{ needs.release.outputs.new_release_version }} \
+            ghcr.io/${{ env.REPO_LC }}:${{ needs.release.outputs.new_release_version }}
+
+      - name: Docker Scout — CVE scan the pushed image
+        # Non-blocking; continue-on-error covers ALL failures (auth/infra) so a Scout error
+        # can't red a release whose dual-push already succeeded (flightdeck #20 review).
+        continue-on-error: true
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: docker.io/oakandwave/swarm-cd:${{ needs.release.outputs.new_release_version }}
+          only-severities: critical,high
+          write-comment: false

--- a/scripts/ci/resolve-index-digest.sh
+++ b/scripts/ci/resolve-index-digest.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Resolve the digest of a pushed multi-arch manifest list (OCI image index).
+#
+# Usage: resolve-index-digest.sh <image-ref>
+#   e.g. resolve-index-digest.sh ghcr.io/wave-engineering/swarm-cd:1.2.3
+#
+# Prints the digest to stdout, and appends `digest=<sha256:...>` to $GITHUB_OUTPUT
+# when running under GitHub Actions.
+#
+# WHY THIS EXISTS: `docker buildx imagetools create` assembles and pushes an index but
+# does not report the resulting digest, so it has to be read back from the registry.
+# Callers need the digest rather than the tag because cosign signatures are bound to an
+# immutable digest -- signing a tag would sign whatever that tag later points at.
+#
+# WHY `{{json .Manifest}}` AND NOT `{{.Manifest.Digest}}`: on buildx 0.21.3 the latter
+# silently falls back to printing imagetools' entire default inspect dump instead of the
+# field value. A *bogus* field name errors, but that valid-looking path does not -- so the
+# failure mode is a plausible-looking command that emits multi-line garbage. The sha256
+# regex below is what converts any such regression into a loud failure.
+set -euo pipefail
+
+ref="${1:?usage: resolve-index-digest.sh <image-ref>}"
+
+manifest="$(docker buildx imagetools inspect "${ref}" --format '{{json .Manifest}}')"
+
+# Assert it really IS an index. Without this the "sign the manifest list, never a per-arch
+# child" guarantee holds only incidentally -- the sha256 regex below accepts any well-formed
+# digest, so a single-arch image manifest would sail through and get signed, and `cosign
+# verify <tag>` against a genuinely multi-arch tag would then find nothing.
+media_type="$(jq -er '.mediaType' <<<"${manifest}")"
+if [[ "${media_type}" != "application/vnd.oci.image.index.v1+json" \
+   && "${media_type}" != "application/vnd.docker.distribution.manifest.list.v2+json" ]]; then
+  echo "resolve-index-digest: ${ref} is not a manifest list/index (mediaType: ${media_type})" >&2
+  exit 1
+fi
+
+digest="$(jq -er '.digest' <<<"${manifest}")"
+
+if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "resolve-index-digest: expected a sha256 digest for ${ref}, got: ${digest}" >&2
+  exit 1
+fi
+
+echo "${digest}"
+
+# `if`, not `[[ ... ]] && echo`: as the script's last command the latter's false branch
+# becomes the script's exit status, so a local run (no GITHUB_OUTPUT) would exit 1 on success.
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
+fi


### PR DESCRIPTION
## Summary

Two stacked changes landing together: the decoupled GHCR→Docker Hub mirror for swarm-cd's multi-arch image (flightdeck #20 replicated, adapted to the by-digest + manifest-list architecture), and cosign keyless signing + syft SBOM attestation of the assembled manifest list on **both** registries.

Signing was stacked on top of the mirror (PR #31, already merged into this branch) because it signs the mirrored copy — the two are only meaningful together. This completes **6 of 6** repos in the fleetwide signing rollout.

## Changes

**Mirror** (`0683923`)
- Lowercase OCI `source`/`url` labels on both arch builds.
- In `push-manifest`: Docker Hub login + mirror the assembled manifest to `docker.io/oakandwave/swarm-cd:{latest,version}` via `imagetools create`; non-blocking Docker Scout.

**Signing** (`b4522fd`, was PR #31 — full detail there)
- `push-manifest`: add `id-token: write` (keyless cosign needs OIDC for Fulcio) + explicit `contents: read`.
- Sign the assembled **GHCR index digest**, then the **Docker Hub index digest** after the mirror, both via cc-workflow's SHA-pinned `oaw-sign-image` action.
- New `scripts/ci/resolve-index-digest.sh` — resolves the created index digest back from the registry (`imagetools create` reports no digest), guarded by a `^sha256:` regex and a `mediaType` assertion that the descriptor really is an index.
- The issue-prescribed `--format '{{.Manifest.Digest}}'` turned out to be **silently broken** on buildx 0.21.3 (prints the whole inspect dump; a bogus field errors, that valid-looking path does not) and was replaced.

The **index** digest is what gets signed, deliberately: consumers pull the tag, which resolves to the index, so one signature covers both arches — per-arch signatures would leave `cosign verify <tag>` finding nothing.

**Ordering is load-bearing** and unchanged by signing: the Docker Hub login stays after the builds, because the `oakandwave` Org Access Token is scoped to `oakandwave/*` and 401s if presented for a public base pull (flightdeck #20).

## Linked Issues

Closes #28
Closes #30

## Test Plan

- `go test ./...` ok (`swarmcd`, `util`, `web`); `go vet ./...` clean; `npm run test` in `ui/` 31/31; `shellcheck` clean; workflow parses.
- All acceptance criteria for both issues asserted programmatically (permissions, 2 sign steps, SHA pin not `@main`, step ordering, build jobs unmodified, no `digest-ref` referencing a tag).
- Digest-resolution script exercised 5 ways against the live registry, including **rejecting a real per-arch child manifest** — the exact wrong-artifact case the mediaType guard exists to prevent.
- Cross-registry index-digest parity verified empirically: `sha256:a2addc5d…` on both registries.
- SBOM measured at ~662 KB / 234 packages, under the rekor body ceiling, so the action's rekor default stands (no TSA needed).
- **Note on checks:** this repo's only workflow triggers on `push` with a `paths` filter (`**.go`, `go.mod`, `go.sum`, `ui/**`, `Dockerfile`) and has no `pull_request` trigger, so PRs run no checks. That is pre-existing, not a skipped gate.
- End-to-end `cosign verify` lands on the next semantic-release publish (`push-manifest` only runs when a release is published).

## Notes

- **Pre-existing dependency CVEs are untouched** — trivy reports 2 CRITICAL + 33 HIGH; pristine `origin/main` yields 32 findings with the same 2 CRITICAL, and neither commit changes a dependency file. Tracked in its own chore issue.
- Unverified follow-up: swarm-cd is the first multi-arch consumer of `oaw-sign-image`; whether `syft` over an index catalogs both arches or only the runner's platform is a hypothesis. If amd64-only, the fix is a `--platform` input on the shared action.
- Downstream-only — concerns the `oakandwave` registry and an OaW internal action; not intended for upstream `m-adawi/swarm-cd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
