### PR TITLE
feat(ci): sign the multi-arch manifest list on both registries (cosign keyless + SBOM)

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -228,8 +228,18 @@ jobs:
     if: ${{ github.ref_name == 'main' && needs.release.outputs.new_release_published == 'true' }}
     runs-on: ubuntu-latest
     permissions:
+      # `contents: read` must be explicit: naming ANY permission sets every unnamed one to
+      # `none`, and this job now checks out the repo (for scripts/ci/ below). Matches the
+      # three sibling repos already on this action.
+      contents: read
       packages: write
+      id-token: write # keyless cosign (Fulcio/Rekor) via the shared oaw-sign-image action
     steps:
+      - name: Checkout
+        # This job previously needed no checkout (it only assembles manifests from the build
+        # jobs' digest artifacts), but scripts/ci/resolve-index-digest.sh below is a repo file.
+        uses: actions/checkout@v4
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -262,6 +272,37 @@ jobs:
         run: |
           docker buildx imagetools inspect ghcr.io/${{ env.REPO_LC }}:latest
 
+      - name: Resolve the manifest-list digest
+        # `imagetools create` does not expose the digest of the index it just created, so
+        # resolve it explicitly -- the sign steps below must target an immutable digest, not
+        # a tag (the shared action hard-refuses any ref lacking @sha256:, so a mistake here
+        # fails loudly rather than signing whatever the tag later points at).
+        #
+        # This is the INDEX digest, and it is deliberately the thing we sign: a consumer
+        # pulls the tag, which resolves to the index, so one signature on the index covers
+        # both arches. Signing the per-arch child digests in the build jobs instead would
+        # leave `cosign verify <tag>` finding nothing.
+        #
+        # The script (not an inline run block) carries the buildx --format caveat and the
+        # sha256 guard, and is locally testable against a real registry.
+        #
+        # Invoked via `bash`, not a direct exec, so this never depends on the execute bit
+        # surviving checkout -- a mode loss would fail exit 126 only on a real release (this
+        # job never runs on a PR), and the shared action encodes the same lesson.
+        id: digest
+        run: bash ./scripts/ci/resolve-index-digest.sh "ghcr.io/${REPO_LC}:${VERSION}"
+        env:
+          VERSION: ${{ needs.release.outputs.new_release_version }}
+
+      - name: Sign the GHCR manifest list (cosign keyless + SBOM)
+        # Consumer of cc-workflow's reusable oaw-sign-image action (fleet signing). The GHCR
+        # login above is active and this job's id-token grants OIDC. SBOM goes to rekor (the
+        # action default): syft over this index measures ~662 KB / 234 packages, well under
+        # rekor's request-body ceiling, so the TSA path (cc-workflow #995) is not needed.
+        uses: wave-engineering/claudecode-workflow/.github/actions/oaw-sign-image@21f10ce601b9340b30fd6df0b4a2e4bd663fe249
+        with:
+          digest-ref: ghcr.io/${{ env.REPO_LC }}@${{ steps.digest.outputs.digest }}
+
       - name: Log in to Docker Hub
         # OAT-safe here: push-manifest only runs imagetools against already-pushed GHCR
         # digests — no docker.io base pull happens in this job, so the oakandwave-scoped
@@ -280,6 +321,15 @@ jobs:
             -t docker.io/oakandwave/swarm-cd:latest \
             -t docker.io/oakandwave/swarm-cd:${{ needs.release.outputs.new_release_version }} \
             ghcr.io/${{ env.REPO_LC }}:${{ needs.release.outputs.new_release_version }}
+
+      - name: Sign the Docker Hub manifest list (cosign keyless + SBOM)
+        # `imagetools create` copies the index content-identically, so the Docker Hub index
+        # digest equals the GHCR one (verified: sha256:a2addc5d... on both registries) -- but
+        # cosign signatures are registry+digest-bound, so the mirror needs its own signature.
+        # The Docker Hub login above is active.
+        uses: wave-engineering/claudecode-workflow/.github/actions/oaw-sign-image@21f10ce601b9340b30fd6df0b4a2e4bd663fe249
+        with:
+          digest-ref: docker.io/oakandwave/swarm-cd@${{ steps.digest.outputs.digest }}
 
       - name: Docker Scout — CVE scan the pushed image
         # Non-blocking; continue-on-error covers ALL failures (auth/infra) so a Scout error

--- a/scripts/ci/resolve-index-digest.sh
+++ b/scripts/ci/resolve-index-digest.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Resolve the digest of a pushed multi-arch manifest list (OCI image index).
+#
+# Usage: resolve-index-digest.sh <image-ref>
+#   e.g. resolve-index-digest.sh ghcr.io/wave-engineering/swarm-cd:1.2.3
+#
+# Prints the digest to stdout, and appends `digest=<sha256:...>` to $GITHUB_OUTPUT
+# when running under GitHub Actions.
+#
+# WHY THIS EXISTS: `docker buildx imagetools create` assembles and pushes an index but
+# does not report the resulting digest, so it has to be read back from the registry.
+# Callers need the digest rather than the tag because cosign signatures are bound to an
+# immutable digest -- signing a tag would sign whatever that tag later points at.
+#
+# WHY `{{json .Manifest}}` AND NOT `{{.Manifest.Digest}}`: on buildx 0.21.3 the latter
+# silently falls back to printing imagetools' entire default inspect dump instead of the
+# field value. A *bogus* field name errors, but that valid-looking path does not -- so the
+# failure mode is a plausible-looking command that emits multi-line garbage. The sha256
+# regex below is what converts any such regression into a loud failure.
+set -euo pipefail
+
+ref="${1:?usage: resolve-index-digest.sh <image-ref>}"
+
+manifest="$(docker buildx imagetools inspect "${ref}" --format '{{json .Manifest}}')"
+
+# Assert it really IS an index. Without this the "sign the manifest list, never a per-arch
+# child" guarantee holds only incidentally -- the sha256 regex below accepts any well-formed
+# digest, so a single-arch image manifest would sail through and get signed, and `cosign
+# verify <tag>` against a genuinely multi-arch tag would then find nothing.
+media_type="$(jq -er '.mediaType' <<<"${manifest}")"
+if [[ "${media_type}" != "application/vnd.oci.image.index.v1+json" \
+   && "${media_type}" != "application/vnd.docker.distribution.manifest.list.v2+json" ]]; then
+  echo "resolve-index-digest: ${ref} is not a manifest list/index (mediaType: ${media_type})" >&2
+  exit 1
+fi
+
+digest="$(jq -er '.digest' <<<"${manifest}")"
+
+if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "resolve-index-digest: expected a sha256 digest for ${ref}, got: ${digest}" >&2
+  exit 1
+fi
+
+echo "${digest}"
+
+# `if`, not `[[ ... ]] && echo`: as the script's last command the latter's false branch
+# becomes the script's exit status, so a local run (no GITHUB_OUTPUT) would exit 1 on success.
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
+fi


### PR DESCRIPTION
## Summary

Adds cosign keyless signing + syft SBOM attestation to the multi-arch image on **both** registries, via cc-workflow's fleet-shared `oaw-sign-image` composite action (SHA-pinned to `21f10ce601b9340b30fd6df0b4a2e4bd663fe249`, identical to the four already-proven consumers). This is **6 of 6** — the last repo in the fleetwide signing rollout.

**Stacked PR:** this targets `feature/28-dockerhub-mirror` (PR #29), not `main`, because the Docker Hub mirror it signs is not yet merged. Merge this first, then #29.

## Changes

- `push-manifest`: add `id-token: write` (keyless cosign needs OIDC to reach Fulcio) and an explicit `contents: read`.
- Sign the assembled **GHCR index digest** after the manifest-list create, before the Docker Hub login.
- Sign the **Docker Hub index digest** after the mirror, before Scout.
- New `scripts/ci/resolve-index-digest.sh` — resolves the created index digest back from the registry, with guards.
- Add `actions/checkout@v4` to `push-manifest` (see below).

### Why the index digest, not the per-arch digests

swarm-cd is the structurally different repo in the fleet: the other five build a single-platform image in one job and sign it there. Here two per-arch jobs push **by digest with no tag**, and a third job assembles the manifest list. A consumer pulls the tag, which resolves to the **index** — so one signature on the index covers both arches, while signatures on the per-arch children would leave `cosign verify <tag>` finding nothing. `push-manifest` is also the only job with both registry logins active, so it is the only place the Docker Hub mirror can be signed at all.

### The prescribed digest-capture command was broken

Issue #30 specified `docker buildx imagetools inspect <tag> --format '{{.Manifest.Digest}}'`. **That command does not work** on buildx 0.21.3 — it ignores the template and prints imagetools' entire default inspect dump. The failure mode is silent *and* selective:

| template | behavior |
| --- | --- |
| `{{.Manifest.Digest}}` | **no error** — falls through to the default formatter |
| `{{.Digest}}` | errors |
| a bogus field name | errors |

A malformed field is loud; that valid-looking path is quiet. Shipped as written, the step would have written the multi-line dump into `$GITHUB_OUTPUT` and handed it to `cosign` — a step that "succeeds" while signing nothing real. Replaced with `--format '{{json .Manifest}}' | jq -er '.digest'`, cross-checked against `--raw | sha256sum` (an OCI digest *is* the SHA-256 of the manifest bytes) — both resolve `sha256:a2addc5d…`. Full write-up on #30.

### Guards, each tested in both directions

- **`^sha256:[0-9a-f]{64}$`** on the resolved value — converts any future template regression from "signs the wrong thing" into "fails the job". Verified: accepts the real digest, rejects the broken template's dump.
- **A `mediaType` assertion that the descriptor really is an index.** Without it the "never sign a per-arch child" guarantee held only *incidentally*, since the regex accepts any well-formed digest. Verified against an actual child manifest (`application/vnd.oci.image.manifest.v1+json`) → rejected, exit 1. Worth noting the obvious counter-example *doesn't* work: buildkit wraps even single-platform builds in an index, so a "single-arch image" still passes — only a true child manifest exercises this.
- **`jq -er` + `set -euo pipefail`** — a registry response missing `digest` exits non-zero instead of emitting the string `null`.

### Two review findings folded in

- **`contents: read` is explicit.** Naming any permission sets every unnamed one to `none`, and this job now checks out the repo. The three sibling repos on this action all set it.
- **The script is invoked via `bash`, not a direct exec**, so it never depends on the execute bit surviving checkout. A mode loss would fail exit 126 — and since `push-manifest` only runs on a `main` release, no PR could ever catch it. The shared action encodes the same lesson.

Logic lives in `scripts/ci/` per `CLAUDE.md:231` (no procedural logic over 5 lines in CI YAML). That also made the guards locally testable against a real registry, which is how two bugs were caught — including one where the script's trailing `[[ ... ]] && echo` made the false branch its **exit status**, so it exited `1` on success whenever `GITHUB_OUTPUT` was unset: it would have passed under Actions and failed everywhere else.

## Linked Issues

Closes #30

## Test Plan

Actually run:

- `go test ./...` — ok (`swarmcd`, `util`, `web`; `cmd` has no tests); `go vet ./...` clean.
- `npm run test` in `ui/` — 31/31 passed.
- `shellcheck scripts/ci/resolve-index-digest.sh` — clean.
- Workflow parses as YAML; all 6 acceptance criteria asserted programmatically (permissions, exactly 2 sign steps, SHA pin not `@main`, step ordering `create < GHCR-sign < DH-login < mirror < DH-sign < Scout`, build jobs unmodified, neither `digest-ref` referencing a tag).
- Script exercised 5 ways against the live registry: index → exit 0 + correct digest; `$GITHUB_OUTPUT` written correctly; per-arch child manifest → exit 1; nonexistent tag → exit 1; missing arg → exit 1.
- Cross-registry index-digest parity confirmed empirically: `sha256:a2addc5d…` on both `ghcr.io/wave-engineering/swarm-cd:latest` and `docker.io/oakandwave/swarm-cd:latest`.
- SBOM size measured (not assumed): ~662 KB SPDX / 234 packages, under the public rekor body ceiling, so the action's rekor default stands rather than the TSA path (cc-workflow #995).

Not run (deferred by design): end-to-end `cosign verify`. `push-manifest` only executes when semantic-release publishes, so proof lands on the next real release:

```
cosign verify \
  --certificate-identity-regexp 'https://github.com/Wave-Engineering/swarm-cd/\.github/workflows/docker-ci\.yaml@.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  <ref>
```

## Notes

- **Pre-existing dependency CVEs are untouched.** trivy reports 2 CRITICAL + 33 HIGH on `go.mod`/`ui/package-lock.json`; scanning pristine `origin/main` yields 32 findings with the same 2 CRITICAL, and this branch changes zero dependency files. Tracked separately.
- **Unverified follow-up:** swarm-cd is the first *multi-arch* consumer of `oaw-sign-image`; whether `syft` over an index catalogs both arches or just the runner's platform is a hypothesis, not a measurement. If the SBOM turns out amd64-only, the fix is a `--platform` input on the shared action, not here.
- Downstream-only: this concerns the `oakandwave` registry and an Oak and Wave internal action, and is not intended for upstream `m-adawi/swarm-cd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)